### PR TITLE
EllipsizingTextView now does not forget Spans.

### DIFF
--- a/src/com/triposo/barone/EllipsizingTextView.java
+++ b/src/com/triposo/barone/EllipsizingTextView.java
@@ -120,7 +120,7 @@ public class EllipsizingTextView extends TextView {
       int after) {
     super.onTextChanged(text, start, before, after);
     if (!programmaticChange) {
-      fullText = text.toString();
+      fullText = text;
       isStale = true;
     }
   }


### PR DESCRIPTION
`fullText` was being converted to `String` from `CharSequence` in `onTextChanged(CharSequence,int,int,int)`